### PR TITLE
fix(ci): run svelte-kit sync before catalog-drift probe

### DIFF
--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -17,6 +17,12 @@ jobs:
         with: { node-version: 20 }
       - name: Install site deps
         run: cd site && npm ci
+      # vitest 4's oxc transform resolves tsconfig.json, which `extends`
+      # ./.svelte-kit/tsconfig.json. That file only exists after a sync, so
+      # without this step the probe fails with "Tsconfig not found" before
+      # any test runs. Site CI gets it for free via `npm run build`.
+      - name: Generate .svelte-kit/tsconfig.json
+        run: cd site && npx svelte-kit sync
       - name: Run catalog-drift invariant
         env:
           CI_PROD_PROBE: "1"


### PR DESCRIPTION
The daily catalog-drift probe has failed every run since the vitest 4
upgrade. vitest 4's oxc transform resolves site/tsconfig.json, which
extends ./.svelte-kit/tsconfig.json — a file that only exists after a
svelte-kit sync. The probe workflow runs vitest directly after npm ci
without building, so oxc aborts with 'Tsconfig not found' before any
test executes (0 tests, suite fails).

Site CI avoids this because its unit-and-build job runs npm run build
(which syncs) first. Add an explicit svelte-kit sync step so the probe
has the same tsconfig available. No catalog drift was actually present.

https://claude.ai/code/session_011FkeEQaHVSAYpnhLHZ81yd