### PR TITLE
fix(container): sweep orphan prereqs in-container to stop false infra failures

### DIFF
--- a/src/container/bc-container-provider.ts
+++ b/src/container/bc-container-provider.ts
@@ -50,6 +50,7 @@ import {
   buildCleanupStaleCandidatesScript,
   buildCompileScript,
   buildPrepareCandidateScript,
+  buildPrereqCleanupScript,
   buildTestScript,
 } from "./bc-script-builders.ts";
 import { resolveSoapTimeoutMs, runTestsViaSoap } from "./soap-test-client.ts";
@@ -1397,50 +1398,71 @@ ${script}
    * E002 Prereq's Product Category table 69001).
    *
    * Filename convention: Publisher_Name_Version.app
+   *
+   * The actual uninstall/unpublish runs INSIDE the container via
+   * `Invoke-ScriptInBcContainer` (see `buildPrereqCleanupScript`), routed
+   * through the warm per-container session slot. The previous host-side
+   * `Unpublish-BcContainerApp` path silently no-opped under pwsh 7 with
+   * `usePwshForBc24 = $false`, so orphans accumulated and tripped cross-task
+   * "defined in multiple apps" publish failures (GitHub issue #10).
+   *
+   * Throws a `ContainerError` if cleanup is incomplete (a prereq survives the
+   * multi-pass sweep) so the failure is attributed to container-state cleanup
+   * rather than the innocent current fixture's publish.
    */
   async cleanupOrphanedPrereqs(
     containerName: string,
     expectedPrereqAppPaths: string[],
   ): Promise<void> {
-    const expected = expectedPrereqAppPaths
+    if (!this.isWindows()) return;
+
+    const expectedNames = expectedPrereqAppPaths
       .map((p) => p.split(/[/\\]/).pop() ?? "")
       .map((fileName) => {
         const parts = fileName.replace(".app", "").split("_");
-        const publisher = parts[0] ?? "";
-        const name = parts.slice(1, -1).join("_");
-        return { publisher, name };
+        // Filename convention: Publisher_Name_Version.app
+        return parts.slice(1, -1).join("_");
       })
-      .filter((x) => x.name.length > 0);
+      .filter((name) => name.length > 0);
 
-    // Quote and join as PowerShell string array literals, e.g.
-    //   $expectedNames = @('CG-AL-E002 Prereq','CG-AL-H022 Prereq')
-    const escapeForPS = (s: string) => s.replace(/'/g, "''");
-    const expectedNamesLit = expected.length === 0 ? "@()" : "@(" +
-      expected.map((e) => `'${escapeForPS(e.name)}'`).join(",") +
-      ")";
+    const script = buildPrereqCleanupScript(
+      containerName,
+      expectedNames,
+      BcContainerProvider.HARNESS_APP_NAME,
+    );
 
-    const script = `
-      Import-Module bccontainerhelper -RequiredVersion 6.1.14 -WarningAction SilentlyContinue
-      $bcContainerHelperConfig.usePwshForBc24 = $false
+    // Route through the persistent per-container session slot (NOT
+    // executePowerShell) so we don't re-pay the ~120 s BCH bridge setup per
+    // task. Mirrors prepareCandidateApp / cleanupStaleCandidates.
+    const result = await this.runScriptThroughSession(
+      containerName,
+      script,
+      "prereq-cleanup",
+    );
 
-      $expectedNames = ${expectedNamesLit}
-      $orphans = @(Get-BcContainerAppInfo -containerName "${containerName}" | Where-Object {
-        $_.Publisher -eq "CentralGauge" -and
-        $_.Name -like "*Prereq*" -and
-        ($expectedNames -notcontains $_.Name)
-      })
-      foreach ($app in $orphans) {
-        try {
-          Write-Output "PREREQ_ORPHAN_REMOVE: $($app.Name) v$($app.Version)"
-          Unpublish-BcContainerApp -containerName "${containerName}" -appName $app.Name -publisher $app.Publisher -version $app.Version -unInstall -doNotSaveData -doNotSaveSchema -force -ErrorAction SilentlyContinue
-        } catch {
-          Write-Output "PREREQ_ORPHAN_WARN: $($app.Name) - $($_.Exception.Message)"
-        }
-      }
-      Write-Output "PREREQ_CLEANUP_DONE"
-    `;
+    if (result.output.includes("PREREQ_CLEANUP_FOUND")) {
+      log.info(`Swept orphan prereqs in ${containerName}`, {
+        output: result.output.split("\n")
+          .filter((l) => l.startsWith("PREREQ_CLEANUP_"))
+          .join(" | "),
+      });
+    }
 
-    await this.executePowerShell(script);
+    // Loud-marker enforcement: if any orphan prereq survived the multi-pass
+    // sweep, fail HERE (container contamination) instead of letting the
+    // subsequent prereq publish fail with a misleading "defined in multiple
+    // apps" attributed to the current fixture.
+    if (
+      result.output.includes("PREREQ_CLEANUP_INCOMPLETE") ||
+      !result.output.includes("PREREQ_CLEANUP_DONE")
+    ) {
+      throw this.buildPwshError({
+        containerName,
+        operation: "setup",
+        message: "Orphan prereq cleanup incomplete (container contamination)",
+        output: result.output,
+      });
+    }
   }
 
   /**

--- a/src/container/bc-script-builders.ts
+++ b/src/container/bc-script-builders.ts
@@ -298,6 +298,134 @@ ${devCredentialSetup}
 }
 
 /**
+ * Build the per-task "orphan prereq" cleanup script: removes CentralGauge
+ * prereq apps left resident by a PRIOR task before the current task publishes
+ * its own prereqs. Without this, two tasks whose prereqs declare the same
+ * object ID (e.g. table 69225 across CG-AL-H022/H023/H024/H026) end up resident
+ * simultaneously and the next publish fails with "defined in multiple apps",
+ * scoring an innocent fixture as an `infra` failure. See GitHub issue #10.
+ *
+ * Why in-container (issue #10). The previous implementation ran host-side
+ * `Unpublish-BcContainerApp` through `executePowerShell` (cold `pwsh`), which is
+ * unreliable under pwsh 7 with `usePwshForBc24 = $false` — it dies after the
+ * first app and the sweep silently no-ops, so orphans accumulate. This builder
+ * mirrors `buildPrepareCandidateScript`: the actual uninstall/unpublish runs
+ * INSIDE the container via `Invoke-ScriptInBcContainer { Get-NAVAppInfo |
+ * Uninstall-NAVApp; Unpublish-NAVApp }`, which works regardless of host shell.
+ * Route it through `runScriptThroughSession` (the warm slot), NOT a fresh
+ * `powershell.exe`, to avoid re-paying the ~120 s BCH bridge setup per task.
+ *
+ * Two-phase ordering (issue #10). The prior task's CANDIDATE app is usually
+ * still installed when this runs (candidate cleanup happens later, inside
+ * `runTests` -> `prepareCandidateApp`), and that candidate depends on the prior
+ * task's prereqs. Removing a prereq while a dependent candidate is still
+ * resident fails ("still in use"), so we remove non-prereq CentralGauge apps
+ * (except the harness) FIRST, then the orphan prereqs — the same ordering the
+ * bench-startup prenuke uses.
+ *
+ * Multi-pass with progress detection. Prereqs can depend on each other
+ * (H024 -> H022): the depended-upon app only unpublishes after its dependent is
+ * gone. We loop, re-querying the remaining orphan set after each pass, and stop
+ * when none remain OR a pass makes no progress (a stuck dependency). A loud
+ * `PREREQ_CLEANUP_INCOMPLETE:<remaining>` marker fires if any survive so the
+ * caller can fail with correct attribution instead of accumulating silently.
+ *
+ * `expectedPrereqNames` are the Names of the CURRENT task's prereqs (which must
+ * stay resident). Anything matching `*Prereq*` under publisher CentralGauge not
+ * in that set is an orphan.
+ *
+ * Output markers (host-side parser keys off these):
+ *   PREREQ_CLEANUP_NONE
+ *   PREREQ_CLEANUP_FOUND:<n>
+ *   PREREQ_CLEANUP_REMOVE:<name> v<version>
+ *   PREREQ_CLEANUP_WARN:<name> - <reason>
+ *   PREREQ_CLEANUP_INCOMPLETE:<remaining>
+ *   PREREQ_CLEANUP_DONE
+ */
+export function buildPrereqCleanupScript(
+  containerName: string,
+  expectedPrereqNames: string[],
+  harnessAppName: string,
+): string {
+  const escapeForPS = (s: string) => s.replace(/'/g, "''");
+  const expectedNamesLit = expectedPrereqNames.length === 0
+    ? "@()"
+    : "@(" + expectedPrereqNames.map((n) => `'${escapeForPS(n)}'`).join(",") +
+      ")";
+  return `
+      Import-Module bccontainerhelper -RequiredVersion 6.1.14 -WarningAction SilentlyContinue
+      $bcContainerHelperConfig.usePwshForBc24 = $false
+
+      $expectedNames = ${expectedNamesLit}
+      try {
+        $report = Invoke-ScriptInBcContainer -containerName "${containerName}" -scriptblock {
+          param($expected, $harnessName)
+          $out = @()
+
+          # Phase 1: remove CentralGauge non-prereq apps (except the harness).
+          # The prior task's candidate depends on its prereqs; it must go first
+          # or the prereq unpublish fails "still in use".
+          $cands = @(Get-NAVAppInfo -ServerInstance BC | Where-Object {
+            $_.Publisher -eq "CentralGauge" -and
+            $_.Name -notlike "*Prereq*" -and
+            $_.Name -ne $harnessName
+          })
+          foreach ($app in $cands) {
+            $out += "PREREQ_CLEANUP_REMOVE:$($app.Name) v$($app.Version)"
+            try { Uninstall-NAVApp -ServerInstance BC -Name $app.Name -Publisher $app.Publisher -Version $app.Version -Force -ErrorAction SilentlyContinue } catch { }
+            try { Unpublish-NAVApp -ServerInstance BC -Name $app.Name -Publisher $app.Publisher -Version $app.Version -ErrorAction Stop } catch {
+              $out += "PREREQ_CLEANUP_WARN:$($app.Name) - $($_.Exception.Message)"
+            }
+          }
+
+          # Phase 2: remove orphan prereqs not in the current task's expected
+          # set, multi-pass for inter-prereq dependency chains.
+          $getOrphans = {
+            @(Get-NAVAppInfo -ServerInstance BC | Where-Object {
+              $_.Publisher -eq "CentralGauge" -and
+              $_.Name -like "*Prereq*" -and
+              ($expected -notcontains $_.Name)
+            })
+          }
+          $remaining = (& $getOrphans).Count
+
+          if ($remaining -eq 0 -and $cands.Count -eq 0) {
+            $out += "PREREQ_CLEANUP_NONE"
+          } else {
+            $out += "PREREQ_CLEANUP_FOUND:$($remaining + $cands.Count)"
+          }
+
+          $maxPasses = 6
+          for ($pass = 1; $pass -le $maxPasses; $pass++) {
+            $orphans = & $getOrphans
+            if ($orphans.Count -eq 0) { $remaining = 0; break }
+            foreach ($app in $orphans) {
+              $out += "PREREQ_CLEANUP_REMOVE:$($app.Name) v$($app.Version)"
+              try { Uninstall-NAVApp -ServerInstance BC -Name $app.Name -Publisher $app.Publisher -Version $app.Version -Force -ErrorAction SilentlyContinue } catch { }
+              try { Unpublish-NAVApp -ServerInstance BC -Name $app.Name -Publisher $app.Publisher -Version $app.Version -ErrorAction Stop } catch {
+                $out += "PREREQ_CLEANUP_WARN:$($app.Name) - $($_.Exception.Message)"
+              }
+            }
+            # Re-query for real progress rather than trusting the calls above
+            # (Uninstall used -ErrorAction SilentlyContinue and BCH/NST can lie).
+            $after = (& $getOrphans).Count
+            $remaining = $after
+            if ($after -eq 0) { break }
+            if ($after -ge $orphans.Count) { break }  # no progress -> stuck dependency
+          }
+
+          if ($remaining -gt 0) { $out += "PREREQ_CLEANUP_INCOMPLETE:$remaining" }
+          $out += "PREREQ_CLEANUP_DONE"
+          $out
+        } -argumentList (,$expectedNames), "${escapeForPS(harnessAppName)}"
+        $report | ForEach-Object { Write-Output $_ }
+      } catch {
+        Write-Output "PREREQ_CLEANUP_WARN:invoke-script - $($_.Exception.Message)"
+      }
+    `;
+}
+
+/**
  * Build the publish app script block
  */
 export function buildPublishScript(

--- a/tests/unit/container/bc-script-builders.test.ts
+++ b/tests/unit/container/bc-script-builders.test.ts
@@ -2,6 +2,7 @@ import { assert, assertStringIncludes } from "@std/assert";
 import {
   buildCleanupStaleCandidatesScript,
   buildPrepareCandidateScript,
+  buildPrereqCleanupScript,
   buildPublishScript,
   buildTestScript,
 } from "../../../src/container/bc-script-builders.ts";
@@ -252,4 +253,113 @@ Deno.test("buildPrepareCandidateScript exits non-zero on publish failure", () =>
     /PREPARE_PUBLISH_FAILED[^\n]*[\s\S]*?exit 1/.test(script),
     "publish failure path must emit PREPARE_PUBLISH_FAILED then exit 1",
   );
+});
+
+// =============================================================================
+// buildPrereqCleanupScript: in-container, two-phase, multi-pass orphan-prereq
+// sweep. Fixes GitHub issue #10 (host-side pwsh-7 sweep silently no-opped ->
+// cross-task object-ID collisions -> false `infra` failures).
+// =============================================================================
+
+Deno.test("buildPrereqCleanupScript routes the unpublish through Invoke-ScriptInBcContainer", () => {
+  // The whole point of the fix: the uninstall/unpublish runs INSIDE the
+  // container (works regardless of host shell), not host-side under pwsh 7.
+  const script = buildPrereqCleanupScript(
+    "Cronus28",
+    ["CG-AL-E002 Prereq"],
+    "CG Test Harness",
+  );
+  assertStringIncludes(script, "Invoke-ScriptInBcContainer");
+});
+
+Deno.test("buildPrereqCleanupScript uses in-container NAV cmdlets, not host-side Unpublish-BcContainerApp", () => {
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Test Harness");
+  assertStringIncludes(script, "Uninstall-NAVApp");
+  assertStringIncludes(script, "Unpublish-NAVApp");
+  assert(
+    !script.includes("Unpublish-BcContainerApp"),
+    "must NOT use the host-side BCH wrapper that fails under pwsh 7",
+  );
+});
+
+Deno.test("buildPrereqCleanupScript scopes to CentralGauge publisher", () => {
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Test Harness");
+  assertStringIncludes(script, `$_.Publisher -eq "CentralGauge"`);
+});
+
+Deno.test("buildPrereqCleanupScript removes non-prereq apps before prereqs (dependency ordering)", () => {
+  // A prior task's candidate depends on its prereqs; it must be removed first
+  // or the prereq unpublish fails "still in use". Phase 1 filter excludes
+  // prereqs and the harness; phase 2 targets prereqs.
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Test Harness");
+  const phase1 = script.indexOf(`$_.Name -notlike "*Prereq*"`);
+  const phase2 = script.indexOf(`$_.Name -like "*Prereq*"`);
+  assert(phase1 >= 0 && phase2 >= 0, "both phases must be present");
+  assert(
+    phase1 < phase2,
+    "non-prereq cleanup (phase 1) must precede prereq cleanup (phase 2)",
+  );
+});
+
+Deno.test("buildPrereqCleanupScript keeps the current task's expected prereqs", () => {
+  const script = buildPrereqCleanupScript(
+    "Cronus28",
+    ["CG-AL-H022 Prereq", "CG-AL-H023 Prereq"],
+    "CG Test Harness",
+  );
+  assertStringIncludes(script, `'CG-AL-H022 Prereq'`);
+  assertStringIncludes(script, `'CG-AL-H023 Prereq'`);
+  assertStringIncludes(script, "$expected -notcontains $_.Name");
+});
+
+Deno.test("buildPrereqCleanupScript excludes the harness by the supplied name", () => {
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Alt Harness");
+  assertStringIncludes(script, `"CG Alt Harness"`);
+  assertStringIncludes(script, "$_.Name -ne $harnessName");
+});
+
+Deno.test("buildPrereqCleanupScript empty expected set yields @()", () => {
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Test Harness");
+  assertStringIncludes(script, "$expectedNames = @()");
+});
+
+Deno.test("buildPrereqCleanupScript loops multi-pass with progress detection", () => {
+  // Inter-prereq dependency chains (H024 -> H022) need repeated passes; the
+  // loop must re-query the orphan set and stop on no-progress.
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Test Harness");
+  assert(
+    /for \(\$pass = 1; \$pass -le/.test(script),
+    "must have a bounded pass loop",
+  );
+  assertStringIncludes(script, "no progress -> stuck dependency");
+});
+
+Deno.test("buildPrereqCleanupScript emits the marker keys the host parser expects", () => {
+  const script = buildPrereqCleanupScript("Cronus28", [], "CG Test Harness");
+  for (
+    const marker of [
+      "PREREQ_CLEANUP_NONE",
+      "PREREQ_CLEANUP_FOUND:",
+      "PREREQ_CLEANUP_REMOVE:",
+      "PREREQ_CLEANUP_WARN:",
+      "PREREQ_CLEANUP_INCOMPLETE:",
+      "PREREQ_CLEANUP_DONE",
+    ]
+  ) {
+    assertStringIncludes(script, marker);
+  }
+});
+
+Deno.test("buildPrereqCleanupScript targets the given container", () => {
+  const script = buildPrereqCleanupScript("Cronus281", [], "CG Test Harness");
+  assertStringIncludes(script, `-containerName "Cronus281"`);
+});
+
+Deno.test("buildPrereqCleanupScript escapes single quotes in expected names", () => {
+  const script = buildPrereqCleanupScript(
+    "Cronus28",
+    ["O'Brien Prereq"],
+    "CG Test Harness",
+  );
+  assertStringIncludes(script, `'O''Brien Prereq'`);
 });


### PR DESCRIPTION
Fixes the orphan-prereq accumulation in #10 that produced false `infra` failures.

## Problem
`cleanupOrphanedPrereqs` is a pre-publish guard meant to sweep prereq apps left by prior tasks before the current task publishes its own. It silently no-opped because:

1. **Host-side under pwsh 7.** It ran `Unpublish-BcContainerApp` via `executePowerShell` (`Deno.Command("pwsh", ...)`). With `usePwshForBc24=$false`, BCH's host wrapper dies after the first app, so the sweep did nothing.
2. **Single-pass**, so inter-dependent prereqs (e.g. H024 -> H022) never fully cleared.

Prereqs accumulated until two declared the same object ID (e.g. table 69225 across H022/H023/H024/H026 + E002). The next publish failed `PREPARE_PUBLISH_FAILED ... defined in multiple apps`, and the innocent running fixture was scored as an `infra` failure (0), ordering-dependent and hard to reproduce.

## Fix
New `buildPrereqCleanupScript` mirrors the existing candidate-cleanup path (`buildPrepareCandidateScript`):

- **In-container** uninstall/unpublish via `Invoke-ScriptInBcContainer { Get-NAVAppInfo | Uninstall-NAVApp; Unpublish-NAVApp }` — works regardless of host shell, sidestepping the pwsh-7 wrapper failure.
- **Two-phase ordering** — remove CentralGauge non-prereq apps (except the harness) *before* orphan prereqs. The prior task's candidate depends on its prereqs and would block their removal otherwise. Matches the bench-startup prenuke ordering.
- **Multi-pass with progress detection** — re-queries the orphan set after each pass (not trusting `-ErrorAction SilentlyContinue`), stops on zero-remaining or no-progress, caps at 6 passes. Handles inter-prereq dependency chains.
- **Loud marker** `PREREQ_CLEANUP_INCOMPLETE` if any survive.

`cleanupOrphanedPrereqs` now routes through `runScriptThroughSession` (the warm slot — no ~120s cold BCH bridge per task) instead of `executePowerShell`, and **throws `ContainerError` on incomplete cleanup** so contamination is attributed to container state rather than the innocent fixture's publish.

### Why not the issue's patch verbatim
The issue's diff switched the host shell to a fresh `Deno.Command("powershell")` (Windows PowerShell 5.1). That's unnecessary (the in-container `Invoke-ScriptInBcContainer` is what fixes it, not the host shell) and harmful (a cold `powershell.exe` per task re-pays the ~120s BCH bridge the warm slot amortizes). On this host, bccontainerhelper 6.1.14 isn't even installed for WinPS 5.1. The two-phase ordering also closes a dependency gap the issue's prereq-only multi-pass didn't address.

## Verification
- `deno check` / `deno lint` / `deno fmt` on changed files: clean.
- `deno test tests/unit/container/bc-script-builders.test.ts`: **28 passed** (11 new).
- **Live on Cronus281:** planted H022+H023 orphan prereqs plus a resident stale candidate, ran `cleanupOrphanedPrereqs(container, [])`:
  ```
  PREREQ_CLEANUP_REMOVE:CentralGauge_CG-AL-E053_1 v1.0.0.0   (phase 1)
  PREREQ_CLEANUP_FOUND:3
  PREREQ_CLEANUP_REMOVE:CG-AL-H023 Prereq v1.0.0.0           (phase 2)
  PREREQ_CLEANUP_REMOVE:CG-AL-H022 Prereq v1.0.0.0
  PREREQ_CLEANUP_DONE
  ```
  All three removed, only the harness left, no `INCOMPLETE`, no throw.

### Coverage note
The multi-pass *dependency-chain* path (H024 -> H022) is unit-tested structurally but not exercised live — only H022/H023 (both independent) are compiled on disk. Did not run real-container integration tests in `tests/unit/container/` (bench-safety; they mutate live Cronus containers).

## Follow-up (separate issue)
The `infra` class still conflates harness contamination with genuine candidate install/runtime errors. Suggest tying `PREREQ_CLEANUP_INCOMPLETE` into the existing dirty-container quarantine/retry path, and not blanket-classifying every "defined in multiple apps" as infra (a model can legitimately collide an object ID). Will file separately.

Refs #10